### PR TITLE
Add checkout API endpoints

### DIFF
--- a/apps/checkout-dashboard/api/app.ts
+++ b/apps/checkout-dashboard/api/app.ts
@@ -11,6 +11,7 @@ import {
 import { findById } from "utils";
 import {
   ChannelActivePaymentProviders,
+  ChannelActivePaymentProvidersByChannel,
   ChannelPaymentOptions,
   CustomizationSettingsValues,
   PaymentProviderSettingsValues,
@@ -32,6 +33,16 @@ export const activePaymentProviders: ChannelActivePaymentProviders = {
   },
 };
 
+export const getActivePaymentProvidersByChannel = (
+  channelId: string
+): ChannelActivePaymentProvidersByChannel =>
+  Object.keys(activePaymentProviders).reduce(
+    (providers, paymentProvider) => ({
+      ...providers,
+      [paymentProvider]: activePaymentProviders[paymentProvider][channelId],
+    }),
+    {} as ChannelActivePaymentProvidersByChannel
+  );
 export const getChannelPaymentOptionsList = (): ChannelPaymentOptions[] =>
   channelList.map((channel) => ({
     id: channel.id,

--- a/apps/checkout-dashboard/pages/api/active-payment-providers.ts
+++ b/apps/checkout-dashboard/pages/api/active-payment-providers.ts
@@ -1,7 +1,6 @@
-import { getChannelPaymentOptionsList } from "api/app";
+import { activePaymentProviders } from "api/app";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const activePaymentProviders = getChannelPaymentOptionsList();
   res.status(200).json(activePaymentProviders);
 }

--- a/apps/checkout-dashboard/pages/api/active-payment-providers/[channelId].ts
+++ b/apps/checkout-dashboard/pages/api/active-payment-providers/[channelId].ts
@@ -1,10 +1,10 @@
-import { getChannelPaymentOptions } from "api/app";
+import { getActivePaymentProvidersByChannel } from "api/app";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { channelId } = req.query;
-  const activePaymentProviders = getChannelPaymentOptions(
+  const activePaymentProvidersForChannel = getActivePaymentProvidersByChannel(
     channelId?.toString()
   );
-  res.status(200).json(activePaymentProviders);
+  res.status(200).json(activePaymentProvidersForChannel);
 }

--- a/apps/checkout-dashboard/pages/api/customization-settings.ts
+++ b/apps/checkout-dashboard/pages/api/customization-settings.ts
@@ -1,7 +1,6 @@
-import { getCustomizationSettings } from "api/app";
+import { customizationSettingsValues } from "api/app";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const customizationSettingsValues = getCustomizationSettings();
   res.status(200).json(customizationSettingsValues);
 }

--- a/apps/checkout-dashboard/pages/api/payment-provider-settings.ts
+++ b/apps/checkout-dashboard/pages/api/payment-provider-settings.ts
@@ -1,7 +1,6 @@
-import { getPaymentProviderSettings } from "api/app";
+import { paymentProviderSettingsValues } from "api/app";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  const paymentProviderSettingsValues = getPaymentProviderSettings();
   res.status(200).json(paymentProviderSettingsValues);
 }

--- a/apps/checkout-dashboard/types/api.ts
+++ b/apps/checkout-dashboard/types/api.ts
@@ -25,6 +25,9 @@ export type ChannelActivePaymentProviders = {
     [K in string]: PaymentProviderID;
   };
 };
+export type ChannelActivePaymentProvidersByChannel = {
+  [P in PaymentMethodID]: PaymentProviderID;
+};
 export type PaymentProviderSettingsValues = {
   [P in PaymentProviderID]: {
     [K in PaymentProviderSettingID<P>]: string;


### PR DESCRIPTION
It adds checkout API endpoints in the dashboard app, currently with mocked data. Available endpoints:
- `/api/active-payment-providers`
- `/api/active-payment-providers/channel-1`
- `/api/payment-provider-settings`
- `/api/customization-settings`

I'll set up real data persistence in another PR. Please review if this api is legitimate for you or not.