### PR TITLE
Address form error handling

### DIFF
--- a/apps/checkout/src/graphql/checkout.graphql
+++ b/apps/checkout/src/graphql/checkout.graphql
@@ -1,5 +1,6 @@
 fragment AccountErrorFragment on AccountError {
   message
+  field
   code
 }
 

--- a/apps/checkout/src/graphql/index.ts
+++ b/apps/checkout/src/graphql/index.ts
@@ -13434,6 +13434,7 @@ export type _Service = {
 export type AccountErrorFragment = {
   __typename?: "AccountError";
   message?: string | null;
+  field?: string | null;
   code: AccountErrorCode;
 };
 
@@ -14225,6 +14226,7 @@ export type UserAddressDeleteMutation = {
     errors: Array<{
       __typename?: "AccountError";
       message?: string | null;
+      field?: string | null;
       code: AccountErrorCode;
     }>;
     address?: {
@@ -14257,6 +14259,7 @@ export type UserAddressUpdateMutation = {
     errors: Array<{
       __typename?: "AccountError";
       message?: string | null;
+      field?: string | null;
       code: AccountErrorCode;
     }>;
     address?: {
@@ -14289,6 +14292,7 @@ export type UserAddressCreateMutation = {
     errors: Array<{
       __typename?: "AccountError";
       message?: string | null;
+      field?: string | null;
       code: AccountErrorCode;
     }>;
     address?: {
@@ -14701,6 +14705,7 @@ export type AddressValidationRulesQuery = {
 export const AccountErrorFragmentDoc = gql`
   fragment AccountErrorFragment on AccountError {
     message
+    field
     code
   }
 `;

--- a/apps/checkout/src/hooks/useCheckout.ts
+++ b/apps/checkout/src/hooks/useCheckout.ts
@@ -10,5 +10,5 @@ export const useCheckout = () => {
     pause: authenticating,
   });
 
-  return { checkout: data!.checkout!, loading };
+  return { checkout: data?.checkout!, loading };
 };

--- a/apps/checkout/src/hooks/useErrorMessages.ts
+++ b/apps/checkout/src/hooks/useErrorMessages.ts
@@ -1,10 +1,33 @@
+import { ValidationErrorCode } from "@/lib/globalTypes";
 import { useFormattedMessages } from "./useFormattedMessages";
 
 export const useErrorMessages = () => {
   const formatMessage = useFormattedMessages();
 
-  return {
+  const errorMessages = {
     invalidValue: formatMessage("invalid"),
     requiredField: formatMessage("required"),
+    requiredValue: formatMessage("required"),
+  };
+
+  const getMessageByErrorCode = (errorCode: ValidationErrorCode) => {
+    switch (errorCode) {
+      case "required":
+        return errorMessages.requiredValue;
+
+      case "invalid":
+        return errorMessages.invalidValue;
+
+      case "missing":
+        return errorMessages.requiredField;
+
+      default:
+        break;
+    }
+  };
+
+  return {
+    errorMessages,
+    getMessageByErrorCode,
   };
 };

--- a/apps/checkout/src/hooks/useFormattedMoney.ts
+++ b/apps/checkout/src/hooks/useFormattedMoney.ts
@@ -8,13 +8,15 @@ export interface Money {
 export const useFormattedMoney = <TMoney extends Money>(
   money: TMoney | undefined
 ) => {
+  if (!money) return "";
+
   const formatter = useNumberFormatter({
     style: "currency",
     currency: money?.currency,
     minimumFractionDigits: 2,
   });
 
-  return money ? formatter.format(money.amount) : "";
+  return formatter.format(money.amount);
 };
 
 export const getFormattedMoney = <TMoney extends Money>(

--- a/apps/checkout/src/lib/globalTypes.ts
+++ b/apps/checkout/src/lib/globalTypes.ts
@@ -12,7 +12,6 @@ export interface ValidationError<TFormData> {
 
 export type AddressField =
   | "city"
-  | "name"
   | "firstName"
   | "lastName"
   | "country"
@@ -24,3 +23,5 @@ export type AddressField =
   | "streetAddress1"
   | "streetAddress2"
   | "phone";
+
+export type ApiAddressField = AddressField | "name";

--- a/apps/checkout/src/lib/globalTypes.ts
+++ b/apps/checkout/src/lib/globalTypes.ts
@@ -2,10 +2,10 @@ export interface Classes {
   className?: string;
 }
 
-export type ValidationErrorType = "invalid" | "missing";
+export type ValidationErrorCode = "invalid" | "missing" | "required";
 
 export interface ValidationError<TFormData> {
-  type: ValidationErrorType;
+  type: ValidationErrorCode;
   path: keyof TFormData;
   message: string;
 }

--- a/apps/checkout/src/lib/globalTypes.ts
+++ b/apps/checkout/src/lib/globalTypes.ts
@@ -1,3 +1,5 @@
+import { AnySchema } from "yup";
+
 export interface Classes {
   className?: string;
 }

--- a/apps/checkout/src/lib/translations/en-US.json
+++ b/apps/checkout/src/lib/translations/en-US.json
@@ -72,5 +72,16 @@
   "paymentProvidersLabel": "payment providers",
   "creditCard": "Credit Card",
   "applePay": "Apple Pay",
-  "paypal": "PayPal"
+  "paypal": "PayPal",
+  "city": "City",
+  "firstName": "First name",
+  "lastName": "Last name",
+  "country": "Country",
+  "countryArea": "Country area",
+  "cityArea": "City area",
+  "postalCode": "Postal code",
+  "companyName": "Company",
+  "streetAddress1": "Street address",
+  "streetAddress2": "Street address (continue)",
+  "phone": "Phone number"
 }

--- a/apps/checkout/src/lib/utils/address.ts
+++ b/apps/checkout/src/lib/utils/address.ts
@@ -1,24 +1,59 @@
-import { AddressField } from "@/lib/globalTypes";
+import uniq from "lodash/uniq";
+import compact from "lodash/compact";
+import { AddressField, ApiAddressField } from "../globalTypes";
 
 const addressFieldsOrder: AddressField[] = [
-  "name",
+  "firstName",
+  "lastName",
   "companyName",
+  "phone",
   "streetAddress1",
   "streetAddress2",
   "city",
   "postalCode",
+  "cityArea",
+  "countryArea",
 ];
 
+// api doesn't approve of "name" so we replace it with "firstName"
+// and "lastName"
+export const getFilteredAddressFields = (
+  addressFields: ApiAddressField[]
+): AddressField[] => {
+  const filteredAddressFields = addressFields.filter(
+    (addressField: ApiAddressField) => addressField !== "name"
+  ) as AddressField[];
+
+  return uniq([...filteredAddressFields, "firstName", "lastName"]);
+};
+
 // api doesn't order the fields but we want to
-export const getSortedAddressFields = (addressFields: AddressField[] = []) =>
-  addressFieldsOrder.reduce((result, orderedAddressField) => {
-    if (!addressFields.includes(orderedAddressField)) {
+export const getSortedAddressFields = (addressFields: AddressField[] = []) => {
+  const filteredAddressFields = getFilteredAddressFields(addressFields);
+
+  return addressFieldsOrder.reduce((result, orderedAddressField) => {
+    if (!filteredAddressFields.includes(orderedAddressField)) {
       return result;
     }
 
     return [...result, orderedAddressField];
   }, [] as AddressField[]);
+};
 
 export const getSortedAddressFieldsFromAddress = (
   address: Partial<Record<AddressField, any>>
 ) => getSortedAddressFields(Object.keys(address) as AddressField[]);
+
+export const ensureArray = <TData extends any[] | null[] | null>(
+  array?: TData
+) => {
+  if (!array) {
+    return [];
+  }
+
+  return compact(array);
+};
+
+export const getRequiredAddressFields = (
+  requiredFields: AddressField[]
+): AddressField[] => [...requiredFields, "firstName", "lastName"];

--- a/apps/checkout/src/lib/utils/validation.ts
+++ b/apps/checkout/src/lib/utils/validation.ts
@@ -2,7 +2,7 @@ import { useErrorMessages } from "@/hooks/useErrorMessages";
 import { ValidationError, ValidationErrorCode } from "@/lib/globalTypes";
 import { ApiErrors } from "@/providers/ErrorsProvider";
 import { useCallback } from "react";
-import { FieldError, FieldErrors } from "react-hook-form";
+import { FieldErrors } from "react-hook-form";
 import { ValidationError as ValidationErrorObject } from "yup";
 import { OptionalObjectSchema } from "yup/lib/object";
 
@@ -65,23 +65,26 @@ export const useValidationResolver = <
     [schema]
   );
 
-export const useFromErrorsFromApiErrors = <TFormData>(
+export const useGetFormErrorsFromApiErrors = <TFormData>(): ((
   apiErrors: ApiErrors<TFormData>
-): FieldErrors<TFormData> => {
+) => FieldErrors<TFormData>) => {
   const { getMessageByErrorCode } = useErrorMessages();
 
-  if (!apiErrors) {
-    return {} as FieldErrors<TFormData>;
-  }
+  const getErrorsFromApi = (apiErrors: ApiErrors<TFormData>) => {
+    if (!apiErrors) {
+      return {} as FieldErrors<TFormData>;
+    }
 
-  console.log(666, apiErrors);
-  return apiErrors.reduce((result, { field, code }) => {
-    const errorCode = code.toLowerCase() as ValidationErrorCode;
+    console.log(666, "API ERRORS", apiErrors);
+    return apiErrors.reduce((result, { field, code }) => {
+      const errorCode = code.toLowerCase() as ValidationErrorCode;
 
-    console.log({ errorCode, lol: getMessageByErrorCode(errorCode) });
-    return {
-      ...result,
-      [field]: { code: errorCode, message: getMessageByErrorCode(errorCode) },
-    };
-  }, {} as FieldErrors<TFormData>);
+      return {
+        ...result,
+        [field]: { code: errorCode, message: getMessageByErrorCode(errorCode) },
+      };
+    }, {} as FieldErrors<TFormData>);
+  };
+
+  return getErrorsFromApi;
 };

--- a/apps/checkout/src/lib/utils/validation.ts
+++ b/apps/checkout/src/lib/utils/validation.ts
@@ -75,7 +75,6 @@ export const useGetFormErrorsFromApiErrors = <TFormData>(): ((
       return {} as FieldErrors<TFormData>;
     }
 
-    console.log(666, "API ERRORS", apiErrors);
     return apiErrors.reduce((result, { field, code }) => {
       const errorCode = code.toLowerCase() as ValidationErrorCode;
 

--- a/apps/checkout/src/lib/utils/validation.ts
+++ b/apps/checkout/src/lib/utils/validation.ts
@@ -1,6 +1,8 @@
-import { ValidationError, ValidationErrorType } from "@/lib/globalTypes";
+import { useErrorMessages } from "@/hooks/useErrorMessages";
+import { ValidationError, ValidationErrorCode } from "@/lib/globalTypes";
+import { ApiErrors } from "@/providers/ErrorsProvider";
 import { useCallback } from "react";
-import { FieldErrors } from "react-hook-form";
+import { FieldError, FieldErrors } from "react-hook-form";
 import { ValidationError as ValidationErrorObject } from "yup";
 import { OptionalObjectSchema } from "yup/lib/object";
 
@@ -23,12 +25,12 @@ export const extractValidationError = <TFormData>({
   ValidationErrorObject,
   "type" | "path" | "message"
 >): ValidationError<TFormData> => ({
-  type: type as ValidationErrorType,
+  type: type as ValidationErrorCode,
   path: path as keyof TFormData,
   message,
 });
 
-const getErrorsAsObject = <TFormData extends Record<string, any>>(
+export const getErrorsAsObject = <TFormData extends Record<string, any>>(
   errors: ValidationError<TFormData>[]
 ): FieldErrors<TFormData> =>
   errors.reduce(
@@ -62,3 +64,24 @@ export const useValidationResolver = <
     },
     [schema]
   );
+
+export const useFromErrorsFromApiErrors = <TFormData>(
+  apiErrors: ApiErrors<TFormData>
+): FieldErrors<TFormData> => {
+  const { getMessageByErrorCode } = useErrorMessages();
+
+  if (!apiErrors) {
+    return {} as FieldErrors<TFormData>;
+  }
+
+  console.log(666, apiErrors);
+  return apiErrors.reduce((result, { field, code }) => {
+    const errorCode = code.toLowerCase() as ValidationErrorCode;
+
+    console.log({ errorCode, lol: getMessageByErrorCode(errorCode) });
+    return {
+      ...result,
+      [field]: { code: errorCode, message: getMessageByErrorCode(errorCode) },
+    };
+  }, {} as FieldErrors<TFormData>);
+};

--- a/apps/checkout/src/providers/ErrorsProvider.tsx
+++ b/apps/checkout/src/providers/ErrorsProvider.tsx
@@ -42,8 +42,8 @@ export const ErrorsProvider = function <TFormData>({
     setErrors(getErrorsFromApi(apiErrors));
   };
 
+  // @ts-ignore
   const clearErrors = () => setErrors({});
-  console.log({ errors });
 
   const providerValues: ErrorsContextConsumerProps<TFormData> = {
     errors,

--- a/apps/checkout/src/providers/ErrorsProvider.tsx
+++ b/apps/checkout/src/providers/ErrorsProvider.tsx
@@ -1,5 +1,5 @@
-import { useFromErrorsFromApiErrors } from "@/lib/utils";
-import { PropsWithChildren } from "react";
+import { useGetFormErrorsFromApiErrors } from "@/lib/utils";
+import { PropsWithChildren, useState } from "react";
 import { FieldErrors } from "react-hook-form";
 import createSafeContext from "./createSafeContext";
 
@@ -14,6 +14,9 @@ export type Errors<TFormData> = FieldErrors<TFormData>;
 export type ErrorsContextConsumerProps<TFormData = any> = {
   errors: Errors<TFormData>;
   hasErrors: boolean;
+  setErrorsFromApi: (apiErrors: ApiErrors<TFormData>) => void;
+  setErrors: (errors: FieldErrors<TFormData>) => void;
+  clearErrors: () => void;
 };
 
 interface ErrorsProviderProps<TFormData> {
@@ -27,8 +30,28 @@ export const ErrorsProvider = function <TFormData>({
   apiErrors,
   children,
 }: PropsWithChildren<ErrorsProviderProps<TFormData>>) {
-  const errors = useFromErrorsFromApiErrors(apiErrors);
+  const getErrorsFromApi = useGetFormErrorsFromApiErrors<TFormData>();
+
+  const [errors, setErrors] = useState<FieldErrors<TFormData>>(
+    getErrorsFromApi(apiErrors)
+  );
+
   const hasErrors = Object.keys(errors).length > 0;
 
-  return <Provider value={{ errors, hasErrors }}>{children}</Provider>;
+  const setErrorsFromApi = (apiErrors: ApiErrors<TFormData>) => {
+    setErrors(getErrorsFromApi(apiErrors));
+  };
+
+  const clearErrors = () => setErrors({});
+  console.log({ errors });
+
+  const providerValues: ErrorsContextConsumerProps<TFormData> = {
+    errors,
+    hasErrors,
+    setErrors,
+    setErrorsFromApi,
+    clearErrors,
+  };
+
+  return <Provider value={providerValues}>{children}</Provider>;
 };

--- a/apps/checkout/src/providers/ErrorsProvider.tsx
+++ b/apps/checkout/src/providers/ErrorsProvider.tsx
@@ -1,0 +1,34 @@
+import { useFromErrorsFromApiErrors } from "@/lib/utils";
+import { PropsWithChildren } from "react";
+import { FieldErrors } from "react-hook-form";
+import createSafeContext from "./createSafeContext";
+
+export type ApiErrors<TFormData> = Array<{
+  field: keyof TFormData;
+  code: "REQUIRED" | "INVALID";
+  message: string;
+}>;
+
+export type Errors<TFormData> = FieldErrors<TFormData>;
+
+export type ErrorsContextConsumerProps<TFormData = any> = {
+  errors: Errors<TFormData>;
+  hasErrors: boolean;
+};
+
+interface ErrorsProviderProps<TFormData> {
+  apiErrors: ApiErrors<TFormData>;
+}
+
+export const [useErrorsContext, Provider] =
+  createSafeContext<ErrorsContextConsumerProps>();
+
+export const ErrorsProvider = function <TFormData>({
+  apiErrors,
+  children,
+}: PropsWithChildren<ErrorsProviderProps<TFormData>>) {
+  const errors = useFromErrorsFromApiErrors(apiErrors);
+  const hasErrors = Object.keys(errors).length > 0;
+
+  return <Provider value={{ errors, hasErrors }}>{children}</Provider>;
+};

--- a/apps/checkout/src/sections/AddressBoxContent.tsx
+++ b/apps/checkout/src/sections/AddressBoxContent.tsx
@@ -20,7 +20,7 @@ export const AddressBoxContent: React.FC<AddressBoxContentProps> = ({
   onEdit,
 }) => {
   const formatMessage = useFormattedMessages();
-  const name = address.name || `${address.firstName} ${address.lastName}`;
+  const name = `${address.firstName} ${address.lastName}`;
 
   return (
     <div className="flex flex-row justify-between w-full">

--- a/apps/checkout/src/sections/CheckoutForm.tsx
+++ b/apps/checkout/src/sections/CheckoutForm.tsx
@@ -19,7 +19,7 @@ interface FormData {
 }
 
 export const CheckoutForm = () => {
-  const errorMessages = useErrorMessages();
+  const { errorMessages } = useErrorMessages();
   const { checkout } = useCheckout();
   const [{ data }, pay] = useFetch(payRequest, { opts: { skip: true } });
 

--- a/apps/checkout/src/sections/Contact/GuestUserForm.tsx
+++ b/apps/checkout/src/sections/Contact/GuestUserForm.tsx
@@ -30,7 +30,7 @@ export const GuestUserForm: React.FC<AnonymousCustomerFormProps> = ({
   defaultValues,
 }) => {
   const formatMessage = useFormattedMessages();
-  const errorMessages = useErrorMessages();
+  const { errorMessages } = useErrorMessages();
   const [createAccountSelected, setCreateAccountSelected] = useState(false);
 
   const schema = object({

--- a/apps/checkout/src/sections/Contact/ResetPassword.tsx
+++ b/apps/checkout/src/sections/Contact/ResetPassword.tsx
@@ -23,7 +23,7 @@ export const ResetPassword: React.FC<ResetPasswordProps> = ({
   onSectionChange,
 }) => {
   const formatMessage = useFormattedMessages();
-  const errorMessages = useErrorMessages();
+  const { errorMessages } = useErrorMessages();
   const { setPassword } = useAuth();
 
   const schema = object({

--- a/apps/checkout/src/sections/Contact/SignInForm.tsx
+++ b/apps/checkout/src/sections/Contact/SignInForm.tsx
@@ -38,7 +38,7 @@ export const SignInForm: React.FC<SignInFormProps> = ({
   defaultValues,
 }) => {
   const formatMessage = useFormattedMessages();
-  const errorMessages = useErrorMessages();
+  const { errorMessages } = useErrorMessages();
   const [passwordResetSent, setPasswordResetSent] = useState(false);
   const { login, requestPasswordReset } = useAuth();
 

--- a/apps/checkout/src/sections/ShippingMethods.tsx
+++ b/apps/checkout/src/sections/ShippingMethods.tsx
@@ -50,6 +50,11 @@ export const ShippingMethods: React.FC<ShippingMethodsProps> = ({}) => {
   return (
     <div className="my-6">
       <Title>{formatMessage("deliveryMethod")}</Title>
+      {!checkout?.shippingAddress && (
+        <Text>
+          Please fill in shipping address to see available shipping methods
+        </Text>
+      )}
       <RadioGroup label={formatMessage("shippingMethodsLabel")}>
         {(checkout?.shippingMethods as ShippingMethod[])?.map(
           ({

--- a/apps/checkout/src/sections/UserAddresses/AddressForm.tsx
+++ b/apps/checkout/src/sections/UserAddresses/AddressForm.tsx
@@ -9,30 +9,49 @@ import {
   getRequiredAddressFields,
   getSortedAddressFields,
 } from "@/lib/utils";
-import { DefaultValues, SubmitHandler, useForm } from "react-hook-form";
+import { useErrorsContext } from "@/providers/ErrorsProvider";
+import forEach from "lodash/forEach";
+import { useEffect } from "react";
+import {
+  DefaultValues,
+  FieldError,
+  Path,
+  SubmitHandler,
+  useForm,
+} from "react-hook-form";
 import { AddressFormData } from "./types";
 
-interface UserAddressFormProps<TFormData extends AddressFormData> {
+interface AddressFormProps<TFormData extends AddressFormData> {
   countryCode: CountryCode;
   defaultValues?: DefaultValues<TFormData>;
   onCancel?: () => void;
   onSave: SubmitHandler<TFormData>;
 }
 
-export const UserAddressForm = <TFormData extends AddressFormData>({
+export const AddressForm = <TFormData extends AddressFormData>({
   countryCode,
   defaultValues,
   onCancel,
   onSave,
-}: UserAddressFormProps<TFormData>) => {
+}: AddressFormProps<TFormData>) => {
   const formatMessage = useFormattedMessages();
+  const { errors, hasErrors } = useErrorsContext();
 
-  const { handleSubmit, watch, getValues, ...rest } = useForm<TFormData>({
-    mode: "onBlur",
-    defaultValues,
-  });
+  const { handleSubmit, watch, getValues, setError, formState, ...rest } =
+    useForm<TFormData>({
+      mode: "onBlur",
+      defaultValues,
+    });
 
-  const getInputProps = useGetInputProps(rest);
+  useEffect(() => {
+    if (hasErrors) {
+      forEach(errors, ({ message }, key) => {
+        setError(key as Path<TFormData>, { message });
+      });
+    }
+  }, [errors]);
+
+  const getInputProps = useGetInputProps({ ...rest, formState });
 
   const [{ data }] = useAddressValidationRulesQuery({
     variables: { countryCode },
@@ -56,7 +75,7 @@ export const UserAddressForm = <TFormData extends AddressFormData>({
           />
         )
       )}
-      <div className="boo">
+      <div>
         {onCancel && (
           <Button
             className="mr-4"

--- a/apps/checkout/src/sections/UserAddresses/AddressForm.tsx
+++ b/apps/checkout/src/sections/UserAddresses/AddressForm.tsx
@@ -64,6 +64,7 @@ export const AddressForm = <TFormData extends AddressFormData>({
     clearErrors,
     ...rest
   } = useForm<TFormData>({
+    // @ts-ignore
     resolver,
     mode: "onBlur",
     defaultValues,
@@ -110,6 +111,7 @@ export const AddressForm = <TFormData extends AddressFormData>({
         (field: AddressField) => (
           <TextInput
             label={formatMessage(field as MessageKey)}
+            // @ts-ignore
             {...getInputProps(field)}
             optional={isFieldOptional(field)}
           />

--- a/apps/checkout/src/sections/UserAddresses/GuestAddressSection.tsx
+++ b/apps/checkout/src/sections/UserAddresses/GuestAddressSection.tsx
@@ -1,12 +1,13 @@
-import { CountryCode } from "@/graphql";
+import { AddressFragment, CountryCode } from "@/graphql";
 import React, { useState } from "react";
 import { AddressFormData } from "./types";
-import { UserAddressForm } from "./UserAddressForm";
+import { AddressForm } from "./AddressForm";
 import { UserAddressSectionContainer } from "./UserAddressSectionContainer";
+import { getAddressFormDataFromAddress } from "./utils";
 
 interface GuestAddressSectionProps {
   onSubmit: (address: AddressFormData) => void;
-  address: AddressFormData;
+  address: AddressFragment;
   title: string;
 }
 
@@ -28,10 +29,10 @@ export const GuestAddressSection: React.FC<GuestAddressSectionProps> = ({
       selectedCountryCode={selectedCountryCode}
       onCountrySelect={setSelectedCountryCode}
     >
-      <UserAddressForm
+      <AddressForm
         onSave={handleSave}
         countryCode={selectedCountryCode}
-        defaultValues={address}
+        defaultValues={getAddressFormDataFromAddress(address)}
       />
     </UserAddressSectionContainer>
   );

--- a/apps/checkout/src/sections/UserAddresses/UserAddressForm.tsx
+++ b/apps/checkout/src/sections/UserAddresses/UserAddressForm.tsx
@@ -1,9 +1,14 @@
 import { Button } from "@/components/Button";
 import { TextInput } from "@/components/TextInput";
 import { CountryCode, useAddressValidationRulesQuery } from "@/graphql";
-import { useFormattedMessages } from "@/hooks/useFormattedMessages";
+import { MessageKey, useFormattedMessages } from "@/hooks/useFormattedMessages";
 import { useGetInputProps } from "@/hooks/useGetInputProps";
 import { AddressField } from "@/lib/globalTypes";
+import {
+  ensureArray,
+  getRequiredAddressFields,
+  getSortedAddressFields,
+} from "@/lib/utils";
 import { DefaultValues, SubmitHandler, useForm } from "react-hook-form";
 import { AddressFormData } from "./types";
 
@@ -35,16 +40,19 @@ export const UserAddressForm = <TFormData extends AddressFormData>({
 
   const validationRules = data?.addressValidationRules;
 
+  const isFieldOptional = (field: AddressField) =>
+    !getRequiredAddressFields(
+      ensureArray(validationRules?.requiredFields)
+    ).includes(field);
+
   return (
     <div>
-      {/* TMP */}
-      {(validationRules?.allowedFields as Partial<AddressField>[])?.map(
+      {getSortedAddressFields(ensureArray(validationRules?.allowedFields))?.map(
         (field: AddressField) => (
           <TextInput
-            label={field}
-            // @ts-ignore TMP
+            label={formatMessage(field as MessageKey)}
             {...getInputProps(field)}
-            optional={!validationRules?.requiredFields?.includes(field)}
+            optional={isFieldOptional(field)}
           />
         )
       )}

--- a/apps/checkout/src/sections/UserAddresses/UserAddressSection.tsx
+++ b/apps/checkout/src/sections/UserAddresses/UserAddressSection.tsx
@@ -10,7 +10,7 @@ import { extractMutationErrors, getById } from "@/lib/utils";
 import { AddressTypeEnum } from "@saleor/sdk/dist/apollo/types";
 import React, { Suspense, useEffect, useState } from "react";
 import { AddressFormData, UserAddressFormData } from "./types";
-import { UserAddressForm } from "./UserAddressForm";
+import { AddressForm } from "./AddressForm";
 import { UserAddressList } from "./UserAddressList";
 import { UserAddressSectionContainer } from "./UserAddressSectionContainer";
 import { getAddressInputData } from "./utils";
@@ -101,7 +101,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
         onCountrySelect={setSelectedCountryCode}
       >
         {displayAddressAdd && (
-          <UserAddressForm
+          <AddressForm
             onSave={handleAddressAdd}
             countryCode={selectedCountryCode}
             onCancel={() => setDisplayAddressAdd(false)}
@@ -109,7 +109,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
         )}
 
         {displayAddressEdit && (
-          <UserAddressForm
+          <AddressForm
             onSave={handleAddressUpdate}
             countryCode={selectedCountryCode}
             defaultValues={

--- a/apps/checkout/src/sections/UserAddresses/UserAddressSection.tsx
+++ b/apps/checkout/src/sections/UserAddresses/UserAddressSection.tsx
@@ -14,6 +14,7 @@ import { AddressForm } from "./AddressForm";
 import { UserAddressList } from "./UserAddressList";
 import { UserAddressSectionContainer } from "./UserAddressSectionContainer";
 import { getAddressInputData } from "./utils";
+import { useErrorsContext } from "@/providers/ErrorsProvider";
 
 export interface UserAddressSectionProps {
   // TMP
@@ -32,6 +33,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
   type,
 }) => {
   const formatMessage = useFormattedMessages();
+  const { setErrorsFromApi } = useErrorsContext();
   const [displayAddressAdd, setDisplayAddressAdd] = useState(false);
 
   const [editedAddressId, setEditedAddressId] = useState<string | null>();
@@ -69,11 +71,14 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
       id: address.id,
     });
 
-    const [hasErrors] = extractMutationErrors(result);
+    const [hasErrors, errors] = extractMutationErrors(result);
 
     if (!hasErrors) {
       setEditedAddressId(null);
+      return;
     }
+
+    setErrorsFromApi(errors);
   };
 
   const handleAddressAdd = async (address: AddressFormData) => {
@@ -85,15 +90,18 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
       type,
     });
 
-    const [hasErrors] = extractMutationErrors(result);
+    const [hasErrors, errors] = extractMutationErrors(result);
 
     if (!hasErrors) {
       setDisplayAddressAdd(false);
+      return;
     }
+
+    setErrorsFromApi(errors);
   };
 
   return (
-    <Suspense fallback="loaden...">
+    <Suspense fallback="loading...">
       <UserAddressSectionContainer
         title={title}
         displayCountrySelect={displayAddressEdit || displayAddressAdd}

--- a/apps/checkout/src/sections/UserAddresses/UserAddresses.tsx
+++ b/apps/checkout/src/sections/UserAddresses/UserAddresses.tsx
@@ -1,19 +1,14 @@
 import { Checkbox } from "@/components/Checkbox";
-import {
-  AddressFragment,
-  useCheckoutBillingAddressUpdateMutation,
-  useCheckoutShippingAddressUpdateMutation,
-  useUserQuery,
-} from "@/graphql";
+import { AddressFragment, useUserQuery } from "@/graphql";
 import { useCheckout } from "@/hooks/useCheckout";
 import { useFormattedMessages } from "@/hooks/useFormattedMessages";
-import { getDataWithToken } from "@/lib/utils";
+import { ErrorsProvider } from "@/providers/ErrorsProvider";
 import { useAuthState } from "@saleor/sdk";
 import React, { useState } from "react";
 import { GuestAddressSection } from "./GuestAddressSection";
-import { AddressFormData, UserAddressFormData } from "./types";
+import { UserAddressFormData } from "./types";
+import { useCheckoutAddressUpdate } from "./useCheckoutAddressUpdate";
 import { UserAddressSection } from "./UserAddressSection";
-import { getAddressInputData } from "./utils";
 
 interface UserAddressesProps {}
 
@@ -23,6 +18,12 @@ export const UserAddresses: React.FC<UserAddressesProps> = ({}) => {
   const { checkout } = useCheckout();
   const [useShippingAsBillingAddress, setUseShippingAsBillingAddressSelected] =
     useState(true);
+  const {
+    shippingAddressUpdateErrors,
+    billingAddressUpdateErrors,
+    updateShippingAddress,
+    updateBillingAddress,
+  } = useCheckoutAddressUpdate({ useShippingAsBillingAddress });
 
   const [{ data }] = useUserQuery({
     pause: !authUser?.id,
@@ -31,66 +32,56 @@ export const UserAddresses: React.FC<UserAddressesProps> = ({}) => {
   const user = data?.user;
   const addresses = user?.addresses;
 
-  const [, checkoutShippingAddressUpdate] =
-    useCheckoutShippingAddressUpdateMutation();
-
-  const handleShippingUpdate = (address: AddressFormData) => {
-    checkoutShippingAddressUpdate(
-      getDataWithToken({ shippingAddress: getAddressInputData(address) })
-    );
-  };
-
-  const [, checkoutBillingAddressUpdate] =
-    useCheckoutBillingAddressUpdateMutation();
-
-  const handleBillingUpdate = (address: AddressFormData) =>
-    checkoutBillingAddressUpdate(
-      getDataWithToken({ billingAddress: getAddressInputData(address) })
-    );
+  const defaultShippingAddress =
+    checkout?.shippingAddress || user?.defaultShippingAddress;
+  const defaultBillingAddress =
+    checkout?.billingAddress || user?.defaultBillingAddress;
 
   return (
     <div>
-      {authUser ? (
-        <UserAddressSection
-          title={formatMessage("shippingAddress")}
-          type="SHIPPING"
-          onAddressSelect={handleShippingUpdate}
-          // @ts-ignore TMP
-          addresses={addresses as UserAddressFormData[]}
-          defaultAddress={user?.defaultShippingAddress}
-        />
-      ) : (
-        <GuestAddressSection
-          // @ts-ignore TMP
-          address={checkout?.shippingAddress as AddressFormData}
-          title={formatMessage("shippingAddress")}
-          onSubmit={handleShippingUpdate}
-        />
-      )}
+      <ErrorsProvider apiErrors={shippingAddressUpdateErrors}>
+        {authUser ? (
+          <UserAddressSection
+            title={formatMessage("shippingAddress")}
+            type="SHIPPING"
+            onAddressSelect={updateShippingAddress}
+            // @ts-ignore TMP
+            addresses={addresses as UserAddressFormData[]}
+            defaultAddress={defaultShippingAddress}
+          />
+        ) : (
+          <GuestAddressSection
+            address={checkout?.shippingAddress as AddressFragment}
+            title={formatMessage("shippingAddress")}
+            onSubmit={updateShippingAddress}
+          />
+        )}
+      </ErrorsProvider>
       <Checkbox
         value="useShippingAsBilling"
         checked={useShippingAsBillingAddress}
         onChange={setUseShippingAsBillingAddressSelected}
         label={formatMessage("useShippingAsBilling")}
       />
-      {!useShippingAsBillingAddress &&
-        (authUser ? (
-          <UserAddressSection
-            title={formatMessage("billingAddress")}
-            type="BILLING"
-            onAddressSelect={handleBillingUpdate}
-            // @ts-ignore TMP
-            addresses={addresses as AddressFragment[]}
-            defaultAddress={user?.defaultBillingAddress}
-          />
-        ) : (
-          <GuestAddressSection
-            title={formatMessage("billingAddress")}
-            onSubmit={handleBillingUpdate}
-            // @ts-ignore TMP
-            address={checkout?.billingAddress as AddressFormData}
-          />
-        ))}
+      {!useShippingAsBillingAddress && (
+        <ErrorsProvider apiErrors={billingAddressUpdateErrors}>
+          {authUser ? (
+            <UserAddressSection
+              title={formatMessage("billingAddress")}
+              type="BILLING"
+              onAddressSelect={updateBillingAddress}
+              addresses={addresses as AddressFragment[]}
+              defaultAddress={defaultBillingAddress}
+            />
+          ) : (
+            <GuestAddressSection
+              address={checkout?.billingAddress as AddressFragment}
+              title={formatMessage("billingAddress")}
+              onSubmit={updateBillingAddress}
+            />
+          )}
+        </ErrorsProvider>
+      )}
     </div>
   );
 };

--- a/apps/checkout/src/sections/UserAddresses/UserAddresses.tsx
+++ b/apps/checkout/src/sections/UserAddresses/UserAddresses.tsx
@@ -16,8 +16,10 @@ export const UserAddresses: React.FC<UserAddressesProps> = ({}) => {
   const formatMessage = useFormattedMessages();
   const { user: authUser } = useAuthState();
   const { checkout } = useCheckout();
+
   const [useShippingAsBillingAddress, setUseShippingAsBillingAddressSelected] =
-    useState(true);
+    useState(!checkout?.billingAddress);
+
   const {
     shippingAddressUpdateErrors,
     billingAddressUpdateErrors,

--- a/apps/checkout/src/sections/UserAddresses/types.ts
+++ b/apps/checkout/src/sections/UserAddresses/types.ts
@@ -2,7 +2,10 @@ import { CountryCode } from "@/graphql";
 import { AddressField } from "@/lib/globalTypes";
 
 export interface AddressFormData
-  extends Omit<Record<AddressField, string>, "country" | "countryCode"> {
+  extends Omit<
+    Record<AddressField, string>,
+    "country" | "countryCode" | "name"
+  > {
   countryCode: CountryCode;
 }
 

--- a/apps/checkout/src/sections/UserAddresses/useCheckoutAddressUpdate.tsx
+++ b/apps/checkout/src/sections/UserAddresses/useCheckoutAddressUpdate.tsx
@@ -66,7 +66,7 @@ export const useCheckoutAddressUpdate = ({
       return;
     }
 
-    const { shippingAddress, billingAddress } = checkout;
+    const { shippingAddress } = checkout;
 
     const shouldUpdateBillingAddress =
       useShippingAsBillingAddress && !!shippingAddress;

--- a/apps/checkout/src/sections/UserAddresses/useCheckoutAddressUpdate.tsx
+++ b/apps/checkout/src/sections/UserAddresses/useCheckoutAddressUpdate.tsx
@@ -1,0 +1,63 @@
+import {
+  useCheckoutBillingAddressUpdateMutation,
+  useCheckoutShippingAddressUpdateMutation,
+} from "@/graphql";
+import { extractMutationErrors, getDataWithToken } from "@/lib/utils";
+import { ApiErrors, Errors } from "@/providers/ErrorsProvider";
+import { useState } from "react";
+import { AddressFormData } from "./types";
+import { getAddressInputData } from "./utils";
+
+export const useCheckoutAddressUpdate = ({
+  useShippingAsBillingAddress,
+}: {
+  useShippingAsBillingAddress: boolean;
+}) => {
+  const [shippingAddressUpdateErrors, setShippingAddressUpdateErrors] =
+    useState<ApiErrors>([]);
+
+  const [billingAddressUpdateErrors, setBillingAddressUpdateErrors] =
+    useState<ApiErrors>([]);
+
+  const [, checkoutShippingAddressUpdate] =
+    useCheckoutShippingAddressUpdateMutation();
+
+  const updateShippingAddress = async (address: AddressFormData) => {
+    const result = await checkoutShippingAddressUpdate(
+      getDataWithToken({ shippingAddress: getAddressInputData(address) })
+    );
+
+    const [hasErrors, errors] = extractMutationErrors(result);
+
+    if (hasErrors) {
+      setShippingAddressUpdateErrors(errors);
+      return;
+    }
+
+    if (useShippingAsBillingAddress) {
+      updateBillingAddress(address);
+    }
+  };
+
+  const [, checkoutBillingAddressUpdate] =
+    useCheckoutBillingAddressUpdateMutation();
+
+  const updateBillingAddress = async (address: AddressFormData) => {
+    const result = await checkoutBillingAddressUpdate(
+      getDataWithToken({ billingAddress: getAddressInputData(address) })
+    );
+
+    const [hasErrors, errors] = extractMutationErrors(result);
+
+    if (hasErrors) {
+      setBillingAddressUpdateErrors(errors);
+    }
+  };
+
+  return {
+    updateShippingAddress,
+    updateBillingAddress,
+    shippingAddressUpdateErrors,
+    billingAddressUpdateErrors,
+  };
+};

--- a/apps/checkout/src/sections/UserAddresses/utils.ts
+++ b/apps/checkout/src/sections/UserAddresses/utils.ts
@@ -8,13 +8,11 @@ import { omit } from "lodash";
 import { AddressFormData } from "./types";
 
 export const getAddressInputData = ({
-  name,
   countryCode,
   country,
   ...rest
 }: Partial<
   AddressFormData & {
-    name?: string;
     countryCode?: CountryCode;
     country: CountryDisplay;
   }
@@ -24,7 +22,7 @@ export const getAddressInputData = ({
 });
 
 export const getAddressFormDataFromAddress = (
-  address: AddressFragment
+  address?: AddressFragment | null
 ): Partial<AddressFormData> => {
   if (!address) {
     return {};

--- a/apps/checkout/src/sections/UserAddresses/utils.ts
+++ b/apps/checkout/src/sections/UserAddresses/utils.ts
@@ -4,8 +4,6 @@ import { AddressFormData } from "./types";
 
 export const getAddressInputData = ({
   name,
-  firstName,
-  lastName,
   countryCode,
   country,
   ...rest
@@ -17,7 +15,5 @@ export const getAddressInputData = ({
   }
 >): AddressInput => ({
   ...omit(rest, ["id", "__typename"]),
-  firstName: firstName || name?.split(" ")[0] || "",
-  lastName: lastName || name?.split(" ")[1] || "",
   country: countryCode || (country?.code as CountryCode),
 });

--- a/apps/checkout/src/sections/UserAddresses/utils.ts
+++ b/apps/checkout/src/sections/UserAddresses/utils.ts
@@ -1,4 +1,9 @@
-import { AddressInput, CountryCode, CountryDisplay } from "@/graphql";
+import {
+  AddressFragment,
+  AddressInput,
+  CountryCode,
+  CountryDisplay,
+} from "@/graphql";
 import { omit } from "lodash";
 import { AddressFormData } from "./types";
 
@@ -17,3 +22,18 @@ export const getAddressInputData = ({
   ...omit(rest, ["id", "__typename"]),
   country: countryCode || (country?.code as CountryCode),
 });
+
+export const getAddressFormDataFromAddress = (
+  address: AddressFragment
+): Partial<AddressFormData> => {
+  if (!address) {
+    return {};
+  }
+
+  const { country, ...rest } = address;
+
+  return {
+    ...rest,
+    countryCode: country.code as CountryCode,
+  } as Partial<AddressFormData>;
+};


### PR DESCRIPTION
- Add error handling to address forms
- Add errors provider to easier handle all them errors in `addUserAddress`, `updateUserAddress`, `updateCheckoutShippingAddress` and `updateCheckoutBillingAddress` forms 
- Add some utils necessary
- Rename some components for more clarity (was a bit difficult to differentiate when all address components start with `User`)
- Temporarily add some ts ignores, will be fixed in upcoming pr's
- Temporarily not translate text in `apps/checkout/src/sections/ShippingMethods.tsx` -> this is probably to be removed so it's untranslated on purpose
- Add auto adding / updating billing address when selecting the `set as billing address` checkbox (move checkout addresses update logic to a hook)

