### PR TITLE
Expose Saleor env vars in app

### DIFF
--- a/apps/checkout-app/next.config.js
+++ b/apps/checkout-app/next.config.js
@@ -19,4 +19,8 @@ module.exports = withTM({
   experimental: {
     esmExternals: false,
   },
+  env: {
+    SALEOR_APP_ID: process.env.SALEOR_APP_ID,
+    SALEOR_APP_TOKEN: process.env.SALEOR_APP_TOKEN,
+  },
 });


### PR DESCRIPTION
Only `NEXT_` vars are appended to Next.js frontend, Saleor env vars need to be defined in Next.js config explicitly.