### PR TITLE
Fix checkout addresses update when user address updated

### DIFF
--- a/apps/checkout/src/providers/BillingSameAsShippingProvider.tsx
+++ b/apps/checkout/src/providers/BillingSameAsShippingProvider.tsx
@@ -1,0 +1,36 @@
+import React, { PropsWithChildren, useRef, useState } from "react";
+import { createSafeContext } from "@/providers/createSafeContext";
+import { useCheckout } from "@/hooks/useCheckout";
+
+interface BillingSameAsShippingContextConsumerProps {
+  isBillingSameAsShippingAddress: boolean;
+  setIsBillingSameAsShippingAddress: (value: boolean) => void;
+  hasBillingSameAsShippingAddressChanged: boolean;
+  setHasBillingSameAsShippingAddressChanged: (value: boolean) => void;
+}
+
+export const [useBillingSameAsShipping, Provider] =
+  createSafeContext<BillingSameAsShippingContextConsumerProps>();
+
+export const BillingSameAsShippingProvider: React.FC<PropsWithChildren<{}>> = ({
+  children,
+}) => {
+  const { checkout } = useCheckout();
+
+  const [isBillingSameAsShippingAddress, setIsBillingSameAsShippingAddress] =
+    useState(!checkout?.billingAddress);
+
+  const [
+    hasBillingSameAsShippingAddressChanged,
+    setHasBillingSameAsShippingAddressChanged,
+  ] = useState(false);
+
+  const providerValues: BillingSameAsShippingContextConsumerProps = {
+    isBillingSameAsShippingAddress,
+    setIsBillingSameAsShippingAddress,
+    hasBillingSameAsShippingAddressChanged,
+    setHasBillingSameAsShippingAddressChanged,
+  };
+
+  return <Provider value={providerValues}>{children}</Provider>;
+};

--- a/apps/checkout/src/sections/Addresses/AddressEditForm.tsx
+++ b/apps/checkout/src/sections/Addresses/AddressEditForm.tsx
@@ -5,6 +5,7 @@ import { useErrors } from "@/providers/ErrorsProvider";
 import React from "react";
 import { AddressForm, AddressFormProps } from "./AddressForm";
 import { UserAddressFormData } from "./types";
+import { useCheckoutAddressUpdate } from "./useCheckoutAddressUpdate";
 import { getAddressInputData } from "./utils";
 
 interface AddressEditFormProps
@@ -19,6 +20,7 @@ export const AddressEditForm: React.FC<AddressEditFormProps> = ({
   defaultValues,
 }) => {
   const [, userAddressUpdate] = useUserAddressUpdateMutation();
+  const { updateShippingAddress } = useCheckoutAddressUpdate();
 
   const { countryCode } = useCountrySelect();
 
@@ -37,6 +39,7 @@ export const AddressEditForm: React.FC<AddressEditFormProps> = ({
     const [hasErrors, errors] = extractMutationErrors(result);
 
     if (!hasErrors) {
+      updateShippingAddress(address);
       onClose();
       return;
     }

--- a/apps/checkout/src/sections/Addresses/Addresses.tsx
+++ b/apps/checkout/src/sections/Addresses/Addresses.tsx
@@ -1,18 +1,15 @@
 import { CountryCode, useUserQuery } from "@/graphql";
 import { useCheckout } from "@/hooks/useCheckout";
+import { BillingSameAsShippingProvider } from "@/providers/BillingSameAsShippingProvider";
 import { CountrySelectProvider } from "@/providers/CountrySelectProvider";
 import { useAuthState } from "@saleor/sdk";
-import React, { useState } from "react";
+import React from "react";
 import { BillingAddressSection } from "./BillingAddressSection";
 import { ShippingAddressSection } from "./ShippingAddressSection";
-import { BillingSameAsShippingAddressProps } from "./types";
 
 export const Addresses: React.FC = () => {
   const { user: authUser } = useAuthState();
   const { checkout } = useCheckout();
-
-  const [isBillingSameAsShippingAddress, setIsBillingSameAsShippingAddress] =
-    useState(!checkout?.billingAddress);
 
   const [{ data }] = useUserQuery({
     pause: !authUser?.id,
@@ -21,13 +18,8 @@ export const Addresses: React.FC = () => {
   const user = data?.me;
   const userAddresses = user?.addresses;
 
-  const billingSameAsShippingProps: BillingSameAsShippingAddressProps = {
-    isBillingSameAsShippingAddress,
-    setIsBillingSameAsShippingAddress,
-  };
-
   return (
-    <div>
+    <BillingSameAsShippingProvider>
       {checkout.isShippingRequired && (
         <CountrySelectProvider
           selectedCountryCode={
@@ -35,7 +27,6 @@ export const Addresses: React.FC = () => {
           }
         >
           <ShippingAddressSection
-            {...billingSameAsShippingProps}
             addresses={userAddresses}
             defaultShippingAddress={user?.defaultShippingAddress}
           />
@@ -47,11 +38,10 @@ export const Addresses: React.FC = () => {
         }
       >
         <BillingAddressSection
-          {...billingSameAsShippingProps}
           addresses={userAddresses}
           defaultBillingAddress={user?.defaultBillingAddress}
         />
       </CountrySelectProvider>
-    </div>
+    </BillingSameAsShippingProvider>
   );
 };

--- a/apps/checkout/src/sections/Addresses/BillingAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/BillingAddressSection.tsx
@@ -57,7 +57,7 @@ export const BillingAddressSection: React.FC<BillingAddressSectionProps> = ({
       type="BILLING"
       onAddressSelect={updateBillingAddress}
       addresses={addresses as AddressFragment[]}
-      defaultAddress={defaultAddress}
+      defaultAddressId={defaultAddress?.id}
     />
   ) : (
     <GuestAddressSection

--- a/apps/checkout/src/sections/Addresses/BillingAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/BillingAddressSection.tsx
@@ -1,51 +1,50 @@
 import { AddressFragment } from "@/graphql";
 import { useCheckout } from "@/hooks/useCheckout";
 import { useFormattedMessages } from "@/hooks/useFormattedMessages";
+import { useBillingSameAsShipping } from "@/providers/BillingSameAsShippingProvider";
 import { useCountrySelect } from "@/providers/CountrySelectProvider";
 import { useAuthState } from "@saleor/sdk";
 import React, { useEffect, useRef } from "react";
 import { GuestAddressSection } from "./GuestAddressSection";
-import {
-  BillingSameAsShippingAddressProps,
-  UserDefaultAddressFragment,
-} from "./types";
+import { UserDefaultAddressFragment } from "./types";
 import { useCheckoutAddressUpdate } from "./useCheckoutAddressUpdate";
 import { UserAddressSection } from "./UserAddressSection";
 
-interface BillingAddressSectionProps extends BillingSameAsShippingAddressProps {
+interface BillingAddressSectionProps {
   addresses?: AddressFragment[] | null;
   defaultBillingAddress: UserDefaultAddressFragment;
 }
 
 export const BillingAddressSection: React.FC<BillingAddressSectionProps> = ({
-  isBillingSameAsShippingAddress,
   defaultBillingAddress,
   addresses = [],
 }) => {
   const formatMessage = useFormattedMessages();
   const { user: authUser } = useAuthState();
   const { checkout } = useCheckout();
-  const hasIsBillingSameAsShippingAddressChanged = useRef(false);
+  const {
+    isBillingSameAsShippingAddress,
+    hasBillingSameAsShippingAddressChanged,
+    setHasBillingSameAsShippingAddressChanged,
+  } = useBillingSameAsShipping();
 
   const { setCountryCodeFromAddress } = useCountrySelect();
 
-  const { updateBillingAddress } = useCheckoutAddressUpdate({
-    isBillingSameAsShippingAddress,
-  });
+  const { updateBillingAddress } = useCheckoutAddressUpdate();
 
   const defaultAddress = checkout?.shippingAddress || defaultBillingAddress;
 
   useEffect(() => {
     if (
       isBillingSameAsShippingAddress ||
-      hasIsBillingSameAsShippingAddressChanged.current
+      hasBillingSameAsShippingAddressChanged
     ) {
       return;
     }
 
     setCountryCodeFromAddress(checkout?.shippingAddress);
 
-    hasIsBillingSameAsShippingAddressChanged.current = true;
+    setHasBillingSameAsShippingAddressChanged(true);
   }, [isBillingSameAsShippingAddress]);
 
   if (checkout?.isShippingRequired && isBillingSameAsShippingAddress) {

--- a/apps/checkout/src/sections/Addresses/ShippingAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/ShippingAddressSection.tsx
@@ -38,7 +38,7 @@ export const ShippingAddressSection: React.FC<ShippingAddressSectionProps> = ({
           onAddressSelect={updateShippingAddress}
           // @ts-ignore TMP
           addresses={addresses as UserAddressFormData[]}
-          defaultAddress={defaultAddress}
+          defaultAddressId={defaultAddress?.id}
         />
       ) : (
         <GuestAddressSection

--- a/apps/checkout/src/sections/Addresses/ShippingAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/ShippingAddressSection.tsx
@@ -2,18 +2,15 @@ import { Checkbox } from "@/components/Checkbox";
 import { AddressFragment } from "@/graphql";
 import { useCheckout } from "@/hooks/useCheckout";
 import { useFormattedMessages } from "@/hooks/useFormattedMessages";
+import { useBillingSameAsShipping } from "@/providers/BillingSameAsShippingProvider";
 import { useAuthState } from "@saleor/sdk";
 import React from "react";
 import { GuestAddressSection } from "./GuestAddressSection";
-import {
-  BillingSameAsShippingAddressProps,
-  UserDefaultAddressFragment,
-} from "./types";
+import { UserDefaultAddressFragment } from "./types";
 import { useCheckoutAddressUpdate } from "./useCheckoutAddressUpdate";
 import { UserAddressSection } from "./UserAddressSection";
 
-export interface ShippingAddressSectionProps
-  extends BillingSameAsShippingAddressProps {
+export interface ShippingAddressSectionProps {
   addresses?: AddressFragment[] | null;
   defaultShippingAddress: UserDefaultAddressFragment;
 }
@@ -21,18 +18,16 @@ export interface ShippingAddressSectionProps
 export const ShippingAddressSection: React.FC<ShippingAddressSectionProps> = ({
   defaultShippingAddress,
   addresses = [],
-  isBillingSameAsShippingAddress,
-  setIsBillingSameAsShippingAddress,
 }) => {
   const formatMessage = useFormattedMessages();
   const { user: authUser } = useAuthState();
   const { checkout } = useCheckout();
+  const { isBillingSameAsShippingAddress, setIsBillingSameAsShippingAddress } =
+    useBillingSameAsShipping();
 
   const defaultAddress = checkout?.shippingAddress || defaultShippingAddress;
 
-  const { updateShippingAddress } = useCheckoutAddressUpdate({
-    isBillingSameAsShippingAddress,
-  });
+  const { updateShippingAddress } = useCheckoutAddressUpdate();
 
   return (
     <>

--- a/apps/checkout/src/sections/Addresses/UserAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/UserAddressSection.tsx
@@ -11,11 +11,13 @@ import { AddressCreateForm } from "./AddressCreateForm";
 import { AddressEditForm } from "./AddressEditForm";
 import { getAddressFormDataFromAddress } from "./utils";
 import { useCountrySelect } from "@/providers/CountrySelectProvider";
-import { useUserAddressSelect } from "./useUserAddressSelect";
+import {
+  useUserAddressSelect,
+  UseUserAddressSelectProps,
+} from "./useUserAddressSelect";
 import { AddressesSkeleton } from ".";
 
-export interface UserAddressSectionProps {
-  defaultAddress?: Pick<AddressFragment, "id"> | null;
+export interface UserAddressSectionProps extends UseUserAddressSelectProps {
   onAddressSelect: (address: UserAddressFormData) => void;
   addresses: AddressFragment[];
   title: string;
@@ -23,7 +25,7 @@ export interface UserAddressSectionProps {
 }
 
 export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
-  defaultAddress,
+  defaultAddressId,
   addresses = [],
   onAddressSelect,
   title,
@@ -34,7 +36,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
   const { selectedAddress, selectedAddressId, setSelectedAddressId } =
     useUserAddressSelect({
       type,
-      defaultAddress,
+      defaultAddressId,
       addresses,
     });
 

--- a/apps/checkout/src/sections/Addresses/UserAddressSection.tsx
+++ b/apps/checkout/src/sections/Addresses/UserAddressSection.tsx
@@ -11,6 +11,8 @@ import { AddressCreateForm } from "./AddressCreateForm";
 import { AddressEditForm } from "./AddressEditForm";
 import { getAddressFormDataFromAddress } from "./utils";
 import { useCountrySelect } from "@/providers/CountrySelectProvider";
+import { useUserAddressSelect } from "./useUserAddressSelect";
+import { AddressesSkeleton } from ".";
 
 export interface UserAddressSectionProps {
   defaultAddress?: Pick<AddressFragment, "id"> | null;
@@ -29,6 +31,13 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
 }) => {
   const formatMessage = useFormattedMessages();
 
+  const { selectedAddress, selectedAddressId, setSelectedAddressId } =
+    useUserAddressSelect({
+      type,
+      defaultAddress,
+      addresses,
+    });
+
   const { setCountryCode } = useCountrySelect();
 
   const [displayAddressCreate, setDisplayAddressCreate] = useState(false);
@@ -39,15 +48,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
 
   const displayAddressList = !displayAddressEdit && !displayAddressCreate;
 
-  const [selectedAddressId, setSelectedAddressId] = useState(
-    defaultAddress?.id
-  );
-
   const editedAddress = addresses.find(getById(editedAddressId as string));
-
-  const selectedAddress = addresses.find(getById(selectedAddressId));
-
-  const onSelectAddress = (id: string) => setSelectedAddressId(id);
 
   const handleSelectCountry = (address?: AddressFragment) => () =>
     setCountryCode(address?.country.code as CountryCode);
@@ -63,7 +64,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
   }, [selectedAddressId]);
 
   return (
-    <Suspense fallback="loading...">
+    <Suspense fallback={<AddressesSkeleton />}>
       <UserAddressSectionContainer
         title={title}
         displayCountrySelect={displayAddressEdit || displayAddressCreate}
@@ -91,7 +92,7 @@ export const UserAddressSection: React.FC<UserAddressSectionProps> = ({
             />
             <UserAddressList
               addresses={addresses as AddressFragment[]}
-              onAddressSelect={onSelectAddress}
+              onAddressSelect={setSelectedAddressId}
               selectedAddressId={selectedAddressId}
               onEditChange={(id: string) => setEditedAddressId(id)}
             />

--- a/apps/checkout/src/sections/Addresses/types.ts
+++ b/apps/checkout/src/sections/Addresses/types.ts
@@ -17,8 +17,3 @@ export type UserDefaultAddressFragment =
   | null
   | undefined
   | { __typename?: "Address"; id: string };
-
-export interface BillingSameAsShippingAddressProps {
-  isBillingSameAsShippingAddress: boolean;
-  setIsBillingSameAsShippingAddress: (value: boolean) => void;
-}

--- a/apps/checkout/src/sections/Addresses/useCheckoutAddressUpdate.tsx
+++ b/apps/checkout/src/sections/Addresses/useCheckoutAddressUpdate.tsx
@@ -5,22 +5,18 @@ import {
 } from "@/graphql";
 import { useCheckout } from "@/hooks/useCheckout";
 import { extractMutationErrors, getDataWithToken } from "@/lib/utils";
+import { useBillingSameAsShipping } from "@/providers/BillingSameAsShippingProvider";
 import { useErrors } from "@/providers/ErrorsProvider";
 import { useEffect } from "react";
-import { AddressFormData, BillingSameAsShippingAddressProps } from "./types";
+import { AddressFormData } from "./types";
 import { getAddressFormDataFromAddress, getAddressInputData } from "./utils";
 
 export type UseAddressUpdateFn = (address: AddressFormData) => Promise<void>;
 
-type UseCheckoutAddressUpdateProps = Pick<
-  BillingSameAsShippingAddressProps,
-  "isBillingSameAsShippingAddress"
->;
-
-export const useCheckoutAddressUpdate = ({
-  isBillingSameAsShippingAddress,
-}: UseCheckoutAddressUpdateProps) => {
+export const useCheckoutAddressUpdate = () => {
   const { checkout } = useCheckout();
+  const { isBillingSameAsShippingAddress } = useBillingSameAsShipping();
+
   const { setApiErrors: setShippingApiErrors } = useErrors<AddressFormData>(
     "checkoutShippingUpdate"
   );

--- a/apps/checkout/src/sections/Addresses/useUserAddressSelect.tsx
+++ b/apps/checkout/src/sections/Addresses/useUserAddressSelect.tsx
@@ -1,0 +1,46 @@
+import { AddressFragment, AddressTypeEnum } from "@/graphql";
+import { useCheckout } from "@/hooks/useCheckout";
+import { getById } from "@/lib/utils";
+import { useEffect, useState } from "react";
+import { isMatchingAddress } from "./utils";
+
+export interface UseUserAddressSelectProps {
+  defaultAddress?: Pick<AddressFragment, "id"> | null;
+  addresses: AddressFragment[];
+  type: AddressTypeEnum;
+}
+
+interface UseUserAddressSelect {
+  selectedAddress?: AddressFragment;
+  selectedAddressId?: string;
+  setSelectedAddressId: (id: string) => void;
+}
+
+export const useUserAddressSelect = ({
+  type,
+  defaultAddress,
+  addresses,
+}: UseUserAddressSelectProps): UseUserAddressSelect => {
+  const { checkout } = useCheckout();
+
+  const [selectedAddressId, setSelectedAddressId] = useState(
+    defaultAddress?.id
+  );
+
+  const selectedAddress = addresses.find(getById(selectedAddressId));
+
+  const addressToWatch =
+    type === "SHIPPING" ? checkout?.shippingAddress : checkout?.billingAddress;
+
+  useEffect(() => {
+    const matchingAddress = addresses.find(isMatchingAddress(addressToWatch));
+
+    setSelectedAddressId(matchingAddress?.id);
+  }, [addressToWatch]);
+
+  return {
+    selectedAddress,
+    selectedAddressId,
+    setSelectedAddressId,
+  };
+};

--- a/apps/checkout/src/sections/Addresses/useUserAddressSelect.tsx
+++ b/apps/checkout/src/sections/Addresses/useUserAddressSelect.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { isMatchingAddress } from "./utils";
 
 export interface UseUserAddressSelectProps {
-  defaultAddress?: Pick<AddressFragment, "id"> | null;
+  defaultAddressId?: string;
   addresses: AddressFragment[];
   type: AddressTypeEnum;
 }
@@ -18,14 +18,12 @@ interface UseUserAddressSelect {
 
 export const useUserAddressSelect = ({
   type,
-  defaultAddress,
+  defaultAddressId,
   addresses,
 }: UseUserAddressSelectProps): UseUserAddressSelect => {
   const { checkout } = useCheckout();
 
-  const [selectedAddressId, setSelectedAddressId] = useState(
-    defaultAddress?.id
-  );
+  const [selectedAddressId, setSelectedAddressId] = useState(defaultAddressId);
 
   const selectedAddress = addresses.find(getById(selectedAddressId));
 

--- a/apps/checkout/src/sections/Addresses/utils.ts
+++ b/apps/checkout/src/sections/Addresses/utils.ts
@@ -5,7 +5,7 @@ import {
   CountryDisplay,
 } from "@/graphql";
 import { AddressField } from "@/lib/globalTypes";
-import { intersection, omit } from "lodash-es";
+import { intersection, isEqual, omit } from "lodash-es";
 import { AddressFormData } from "./types";
 
 export const getAddressInputData = ({
@@ -66,3 +66,8 @@ export const getAddressFormLayout = (orderedAdressFields: AddressField[]) =>
 
     return result;
   }, [] as AddressFormLayout);
+
+export const isMatchingAddress =
+  (address?: AddressFragment | null) =>
+  (addressToMatch?: AddressFragment | null) =>
+    isEqual(omit(address, "id"), omit(addressToMatch, "id"));


### PR DESCRIPTION
- Add BillingSameAsShippingProvider because we needed this prop in multiple places on many different levels and the prop drilling became quite horrible
- Add address list item auto selection based on checkout existing shipping / billing address (since the id of checkout shipping address and user address (the one on the list) are different, we previously couldn't auto select address based on that, and when checkout was opened in a new tab for instance, user would have a shipping address in checkout but none selected in the list)
- Add auto selecting address after address update (there is still a bug related to checkout loading state I described in the fixing ticket, fix will be added there). Currently the address is being updated, but there is a race condition with checkout reloading it's data so sometimes it's outdated address and not the updated one