### PR TITLE
Fix Mollie logo displayed two times

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,13 @@ Click deploy and wait until the app is deployed
 
 Checkout app supports two payment gateways that you can configure:
 
-[![Mollie](./docs/logos/mollie_light.svg#gh-dark-mode-only) ![Mollie](./docs/logos/mollie_dark.svg#gh-light-mode-only)](https://www.mollie.com/en)
+<a href="https://www.mollie.com/en">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/logos/mollie_light.svg">
+    <source media="(prefers-color-scheme: light)" srcset="./docs/logos/mollie_dark.svg">
+    <img alt="Mollie" src="./docs/logos/mollie_dark.svg">
+  </picture>
+</a>
 
 <br>
 


### PR DESCRIPTION
Fixes Mollie logo displayed two times in README. I've used the new GitHub dark mode for images format: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to