### PR TITLE
Fix typo in a variable name

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
       "dependsOn": [
         "^build",
         "$SALEOR_API_URL",
-        "$CHECKOUT_API_URL",
+        "$CHECKOUT_APP_URL",
         "$REACT_APP_SALEOR_API_URL",
         "$REACT_APP_CHECKOUT_APP_URL",
         "$SALEOR_APP_TOKEN",


### PR DESCRIPTION
Found in a fork here: https://github.com/chrislais/saleor-checkout/commit/46e352226055cfe1538d79a9dff9c213786689de